### PR TITLE
Don't automatically set keepinventory to true if the inventory should not get cleared.

### DIFF
--- a/src/main/java/com/faris/kingkits/listener/EventListener.java
+++ b/src/main/java/com/faris/kingkits/listener/EventListener.java
@@ -327,8 +327,6 @@ public class EventListener implements Listener {
 					player.getInventory().clear();
 					player.getInventory().setArmorContents(null);
 					player.updateInventory();
-				} else {
-					event.setKeepInventory(true);
 				}
 				kitPlayer.onDeath();
 				if (killer != null && !player.getUniqueId().equals(killer.getUniqueId())) {


### PR DESCRIPTION

This can break other plugins who also handle the keep-inventory setting.